### PR TITLE
update default ODE algorithms

### DIFF
--- a/src/ode_default_alg.jl
+++ b/src/ode_default_alg.jl
@@ -31,14 +31,24 @@ function default_algorithm{uType,tType,inplace}(prob::AbstractODEProblem{uType,t
       end
     end
   else # The problem is stiff
-    if uEltype <: Float64 # Sundials only works on Float64!
-      if tol_level == :high_tol || callbacks || mm # But not in these cases
-        alg = Rosenbrock23()
-      else
-        alg = Rodas4()
-      end
+    if uType <: Array{Float64} && !mm && length(prob.u0) > 1000
+      # Sundials only works on Float64!
+      # Sundials is fast when problems are large enough
+      alg = CVODE_BDF()
+    elseif uType <: Array{Float64} && !mm && length(prob.u0) > 10000
+      # Use Krylov method when huge!
+      alg = CVODE_BDF(linear_solver=:BCG)
     else
       alg = Rosenbrock23()
+    end
+    if tol_level == :high_tol
+      alg = Rosenbrock23()
+    else
+      if eltype(prob.u0) <: Float64
+        alg = Rodas4()
+      else # This is only for Julia v0.6 lufact! bug
+        alg = Rodas4(linsolve=LinSolveFactorize(qrfact!))
+      end
     end
   end
   alg,extra_kwargs

--- a/test/default_ode_alg_test.jl
+++ b/test/default_ode_alg_test.jl
@@ -42,11 +42,11 @@ default_algorithm(prob_ode_bigfloat2Dlinear;alg_hints=[:stiff])
 
 sol =solve(prob_ode_bigfloat2Dlinear;alg_hints=[:stiff])
 
-@test typeof(sol.alg) <: Rosenbrock23
+@test typeof(sol.alg) <: Rodas4
 
 sol =solve(prob_ode_bigfloat2Dlinear,nothing;alg_hints=[:stiff])
 
-@test typeof(sol.alg) <: Rosenbrock23
+@test typeof(sol.alg) <: Rodas4
 
 immutable FooAlg end
 
@@ -68,10 +68,10 @@ sol =solve(prob;alg_hints=[:stiff],reltol=1e-1)
 
 sol =solve(prob;alg_hints=[:stiff],callback=CallbackSet())
 
-@test typeof(sol.alg) <: Rosenbrock23
+@test typeof(sol.alg) <: Rodas4
 
 prob_mm = ODEProblem(f,rand(4,2).*ones(4,2)/2,(0.0,1.0),mass_matrix=nothing)
 
 alg, kwargs = default_algorithm(prob_mm;alg_hints=[:stiff])
 
-@test typeof(alg) <: Rosenbrock23
+@test typeof(alg) <: Rodas4


### PR DESCRIPTION
This makes the stiff choice a lot more intricate, taking into account the size of u0 to choose Sundials and possibly choose a Krylov method when dense solvers are too expensive.