### PR TITLE
Update algorithm defaults

### DIFF
--- a/src/dde_default_alg.jl
+++ b/src/dde_default_alg.jl
@@ -6,7 +6,7 @@ function default_algorithm{uType,tType,lType,isinplace}(prob::AbstractDDEProblem
   alg_hints = get_alg_hints(o)
 
   if :stiff ∈ alg_hints
-    alg=MethodOfSteps(Rosenbrock23())
+    alg=MethodOfSteps(Rosenbrock23(autodiff=false))
   end
 
   # If adaptivity is not set and the tType is not a float, turn off adaptivity

--- a/test/default_sde_alg_test.jl
+++ b/test/default_sde_alg_test.jl
@@ -4,10 +4,10 @@ srand(100)
 
 prob = prob_sde_additive
 sol =solve(prob,dt=1/2^(3))
-@test typeof(sol.alg) <: SRIW1
+@test typeof(sol.alg) <: SOSRI
 
 sol =solve(prob,dt=1/2^(3),alg_hints=[:additive])
-@test typeof(sol.alg) <: SRA1
+@test typeof(sol.alg) <: SOSRA
 
 sol =solve(prob,dt=1/2^(3),alg_hints=[:stratonovich])
 @test StochasticDiffEq.alg_interpretation(sol.alg) == :stratonovich
@@ -26,8 +26,14 @@ g = function (du,u,p,t)
 end
 prob = SDEProblem(f,g,ones(2),(0.0,1.0),noise_rate_prototype=zeros(2,4))
 
-sol =solve(prob,dt=1/2^(3),alg_hints=[:additive])
+sol =solve(prob,dt=1/2^(3))
 @test typeof(sol.alg) <: EM
+
+sol =solve(prob,dt=1/2^(3),alg_hints=[:stiff])
+@test typeof(sol.alg) <: ISSEM
+
+sol =solve(prob,dt=1/2^(3),alg_hints=[:additive])
+@test typeof(sol.alg) <: SOSRA
 
 sol =solve(prob,dt=1/2^(3),alg_hints=[:stratonovich])
 @test typeof(sol.alg) <: EulerHeun


### PR DESCRIPTION
Does a few things:

1) It makes finite differencing the default. This is usually safer at a small cost. @gabrielgellner 
2) It updates the SDE defaults for the newest stability-optimized methods.
3) It defaults to non-stiff if no choice is given and the size of the problem is sufficiently large. @tkf