### PR TITLE
Readme: Remove excess whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ include:
 - (Stochastic) partial differential equations ((S)PDEs) (with both finite
   difference and finite element methods)
 
-The well-optimized DifferentialEquations solvers benchmark as the some of the fastest  
+The well-optimized DifferentialEquations solvers benchmark as the some of the fastest
 implementations, using classic algorithms and ones from recent research which
 routinely outperform the "standard" C/Fortran methods, and include algorithms
 optimized for high-precision and HPC applications. At the same time, it wraps
@@ -87,5 +87,3 @@ could cite our work.
 ## Example Images
 
 <img src="https://raw.githubusercontent.com/JuliaDiffEq/DifferentialEquations.jl/master/assets/DifferentialEquations_Example.png" align="middle"  />
-
-


### PR DESCRIPTION
A double space at the end of a line in markdown forces a hard line break, which looks bad (IMO) if it's in the wrong place. But maybe you intended it this way?

It looks especially weird on my screen because I force text justification via css ;)